### PR TITLE
ci: ubuntu base image for cross-platform

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # This Dockerfile is used for cross-platform builds
 
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/cc-debian12
+FROM --platform=$TARGETPLATFORM ubuntu:24.04
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
## 🎯 Problem
Change cross-platform Dockerfile uses distroless as base image, so that makes debugging and in-container orchestration quite difficult as there are no other unix binary.

## 🔧 Solution
Using Ubuntu as a base image, just like reth upstream project

## 👷 Tests

Image build : https://github.com/auricom/lumen/actions/runs/15870581080/job/44748075582

Now we can execute /bin/bash inside the container

```
❯ docker run --entrypoint /bin/bash ghcr.io/auricom/lumen:latest 
0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the base image used for cross-platform builds to improve compatibility. No impact on application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->