### PR TITLE
chore: update reth dependencies to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcb57295c4b632b6b3941a089ee82d00ff31ff9eb3eac801bf605ffddc81041"
+checksum = "e9c6ad411efe0f49e0e99b9c7d8749a1eb55f6dbf74a1bc6953ab285b02c4f67"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab669be40024565acb719daf1b2a050e6dc065fc0bec6050d97a81cdb860bd7"
+checksum = "0bf397edad57b696501702d5887e4e14d7d0bbae9fbb6439e148d361f7254f45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f853de9ca1819f54de80de5d03bfc1bb7c9fafcf092b480a654447141bc354d"
+checksum = "749b8449e4daf7359bdf1dabdba6ce424ff8b1bdc23bdb795661b2e991a08d87"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a02725f099ba3469df67ab9bb0de386a1108365dbdfa68d1391773534f9dbcb"
+checksum = "a198edb5172413c2300bdc591b4dec1caa643398bd7facc21d0925487dffcd8f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -257,22 +257,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500bcc1037901953771c25cb77e0d4ec0bffd938d93a04715390230d21a612d"
+checksum = "5fcbae2107f3f2df2b02bb7d9e81e8aa730ae371ca9dd7fd0c81c3d0cb78a452"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.7"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977d2492ce210e34baf7b36afaacea272c96fbe6774c47e23f97d14033c0e94f"
+checksum = "4ce138b29a2f8e7ed97c064af8359dfa6559c12cba5e821ae4eb93081a56557e"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -296,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4997a9873c8639d079490f218e50e5fa07e70f957e9fc187c0a0535977f482f"
+checksum = "bc30b0e20fcd0843834ecad2a716661c7b9d5aca2486f8e96b93d5246eb83e06"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -311,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0306e8d148b7b94d988615d367443c1b9d6d2e9fecd2e1f187ac5153dce56f5"
+checksum = "eaeb681024cf71f5ca14f3d812c0a8d8b49f13f7124713538e66d74d3bfe6aff"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -337,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eef189583f4c53d231dd1297b28a675ff842b551fb34715f562868a1937431a"
+checksum = "a03ad273e1c55cc481889b4130e82860e33624e6969e9a08854e0f3ebe659295"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -364,7 +365,7 @@ dependencies = [
  "foldhash",
  "getrandom 0.3.3",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -381,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea624ddcdad357c33652b86aa7df9bd21afd2080973389d3facf1a221c573948"
+checksum = "abc164acf8c41c756e76c7aea3be8f0fb03f8a3ef90a33e3ddcea5d1614d8779"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -412,7 +413,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -424,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea3227fa5f627d22b7781e88bc2fe79ba1792d5535b4161bc8fc99cdcd8bedd"
+checksum = "670d155c3e35bcaa252ca706a2757a456c56aa71b80ad1539d07d49b86304e78"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -467,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43d00b4de38432304c4e4b01ae6a3601490fd9824c852329d158763ec18663c"
+checksum = "03c44d31bcb9afad460915fe1fba004a2af5a07a3376c307b9bdfeec3678c209"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -481,7 +482,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "tokio",
@@ -495,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf22ddb69a436f28bbdda7daf34fe011ee9926fa13bfce89fa023aca9ce2b2f"
+checksum = "2ba2cf3d3c6ece87f1c6bb88324a997f28cf0ad7e98d5e0b6fa91c4003c30916"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -508,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa84dd9d9465d6d3718e91b017d42498ec51a702d9712ebce64c2b0b7ed9383"
+checksum = "e4ce874dde17cc749f1aa8883e0c1431ddda6ba6dd9c9eb9b31d1fb0a6023830"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -520,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecd1c60085d8cbc3562e16e264a3cd68f42e54dc16b0d40645e5e42841bc042"
+checksum = "65e80e2ffa56956a92af375df1422b239fde6552bd222dfeaeb39f07949060fa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -532,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5958f2310d69f4806e6f6b90ceb4f2b781cc5a843517a7afe2e7cfec6de3cfb9"
+checksum = "ef5b22062142ce3b2ed3374337d4b343437e5de6959397f55d2c9fe2c2ce0162"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -543,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83868430cddb02bb952d858f125b824ddbc74dde0fb4cdc5c345c732d66936b"
+checksum = "438a7a3a5c5d11877787e324dd1ffd9ab82314ca145513ebe8d12257cbfefb5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -561,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c293df0c58d15330e65599f776e30945ea078c93b1594e5c4ba0efaad3f0a739"
+checksum = "1f53a2a78b44582e0742ab96d5782842d9b90cebf6ef6ccd8be864ae246fdd0f"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -571,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5b09d86d0c015cb8400c5d1d0483425670bef4fc1260336aea9ef6d4b9540c"
+checksum = "7041c3fd4dcd7af95e86280944cc33b4492ac2ddbe02f84079f8019742ec2857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -592,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1826285e4ffc2372a8c061d5cc145858e67a0be3309b768c5b77ddb6b9e6cbc7"
+checksum = "391e59f81bacbffc7bddd2da3a26d6eec0e2058e9237c279e9b1052bdf21b49e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -613,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94fb27232aac9ee5785bee2ebfc3f9c6384a890a658737263c861c203165355"
+checksum = "de3f327d4cd140eca2c6c27c82c381aba6fa6a32cbb697c146b5607532f82167"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -628,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e8f7fa774a1d6f7b3654686f68955631e55f687e03da39c0bd77a9418d57a1"
+checksum = "29d96238f37e8a72dcf2cf6bead4c4f91dec1c0720b12be10558406e1633a804"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -642,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39d9218a0fd802dbccd7e0ce601a6bdefb61190386e97a437d97a31661cd358"
+checksum = "e45d00db47a280d0a6e498b6e63344bccd9485d8860d2e2f06b680200c37ebc2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -654,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906ce0190afeded19cb2e963cb8507c975a7862216b9e74f39bf91ddee6ae74b"
+checksum = "0ea08bc854235d4dff08fd57df8033285c11b8d7548b20c6da218194e7e6035f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -666,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89baab06195c4be9c5d66f15c55e948013d1aff3ec1cfb0ed469e1423313fce"
+checksum = "bcb3759f85ef5f010a874d9ebd5ee6ce01cac65211510863124e0ebac6552db0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -681,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a249a923e302ac6db932567c43945392f0b6832518aab3c4274858f58756774"
+checksum = "14d95902d29e1290809e1c967a1e974145b44b78f6e3e12fc07a60c1225e3df0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -718,7 +719,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -767,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1ae10b1bc77fde38161e242749e41e65e34000d05da0a3d3f631e03bfcb19e"
+checksum = "dcdf4b7fc58ebb2605b2fc5a33dae5cf15527ea70476978351cc0db1c596ea93"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -790,13 +791,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b234272ee449e32c9f1afbbe4ee08ea7c4b52f14479518f95c844ab66163c545"
+checksum = "4c4b0f3a9c28bcd3761504d9eb3578838d6d115c8959fc1ea05f59a3a8f691af"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde_json",
  "tower",
  "tracing",
@@ -805,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061672d736144eb5aae13ca67cfec8e5e69a65bef818cb1a2ab2345d55c50ab4"
+checksum = "758edb7c266374374e001c50fb1ea89cb5ed48d47ffbf297599f2a557804dd3b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -825,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b01f10382c2aea797d710279b24687a1e9e09a09ecd145f84f636f2a8a3fcc"
+checksum = "c5596b913d1299ee37a9c1bb5118b2639bf253dc1088957bdf2073ae63a6fdfa"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -843,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -863,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75ef8609ea2b31c799b0a56c724dca4c73105c5ccc205d9dfeb1d038df6a1da"
+checksum = "79bf2869e66904b2148c809e7a75e23ca26f5d7b46663a149a1444fb98a69d1d"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -1630,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2108,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -3158,7 +3159,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3167,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3177,7 +3178,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3467,7 +3468,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3740,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "arbitrary",
  "equivalent",
@@ -3812,6 +3813,17 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4206,9 +4218,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -4236,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4655,7 +4667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -5032,14 +5044,14 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
- "const-hex",
  "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -5071,9 +5083,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.6"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5448a4ef9ef1ee241a67fe533ae3563716bbcd719acbd0544ad1ac9f03cfde6"
+checksum = "a8719d9b783b29cfa1cf8d591b894805786b9ab4940adc700a57fd0d5b721cf5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5089,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.6"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c2b1be5c3414f29800d1b29cd16f0049b847687143adb19814de587ecb3f6"
+checksum = "6a4559d84f079b3fdfd01e4ee0bb118025e92105fbb89736f5d77ab3ca261698"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5108,9 +5120,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "7.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b97d2b54651fcd2955b454e86b2336c031e17925a127f4c44e2b63b2eeda923"
+checksum = "84de364c50baff786d09ab18d3cdd4f5ff23612e96c00a96b65de3c470f553df"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -5966,9 +5978,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6015,8 +6027,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6039,8 +6051,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6070,8 +6082,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6090,8 +6102,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6104,8 +6116,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6127,7 +6139,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "ratatui",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -6182,8 +6194,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6192,8 +6204,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6211,8 +6223,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6231,8 +6243,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6242,8 +6254,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6257,8 +6269,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6270,8 +6282,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6282,8 +6294,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6295,7 +6307,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tracing",
@@ -6306,8 +6318,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6332,8 +6344,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6360,8 +6372,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6389,8 +6401,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6404,8 +6416,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6430,8 +6442,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6454,8 +6466,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6478,8 +6490,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6508,8 +6520,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6539,8 +6551,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6561,8 +6573,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6586,8 +6598,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "futures",
  "pin-project",
@@ -6609,8 +6621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6656,8 +6668,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6683,8 +6695,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6699,14 +6711,14 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-fs-util",
  "sha2 0.10.9",
  "tokio",
@@ -6714,15 +6726,18 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
+ "reth-ethereum-primitives",
  "reth-etl",
  "reth-fs-util",
  "reth-primitives-traits",
@@ -6735,8 +6750,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6746,8 +6761,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6775,8 +6790,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6799,13 +6814,14 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "reth-chainspec",
  "reth-cli-util",
+ "reth-codecs",
  "reth-consensus",
  "reth-consensus-common",
  "reth-db",
@@ -6835,8 +6851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6894,8 +6910,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6910,8 +6926,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6928,8 +6944,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6942,8 +6958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6969,8 +6985,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6987,8 +7003,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6997,8 +7013,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7020,8 +7036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7039,8 +7055,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7052,8 +7068,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7070,8 +7086,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7108,8 +7124,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7122,8 +7138,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "serde",
  "serde_json",
@@ -7132,8 +7148,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7160,8 +7176,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "bytes",
  "futures",
@@ -7180,14 +7196,14 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
  "dashmap 6.1.0",
  "derive_more",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
@@ -7197,8 +7213,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "bindgen",
  "cc",
@@ -7206,8 +7222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "futures",
  "metrics",
@@ -7218,20 +7234,20 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -7240,8 +7256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7295,8 +7311,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -7318,8 +7334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7340,8 +7356,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7355,8 +7371,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7369,8 +7385,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7386,8 +7402,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7410,8 +7426,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7474,8 +7490,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7503,9 +7519,9 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives-traits",
  "reth-prune-types",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
@@ -7525,8 +7541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-rpc-types-engine",
@@ -7561,8 +7577,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7585,8 +7601,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -7606,8 +7622,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7619,8 +7635,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7638,8 +7654,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7658,8 +7674,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7670,8 +7686,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7689,8 +7705,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7699,8 +7715,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -7713,8 +7729,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7746,8 +7762,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7791,8 +7807,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7819,8 +7835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7833,8 +7849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7846,8 +7862,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7897,11 +7913,11 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
+ "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -7922,8 +7938,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7950,8 +7966,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7987,9 +8003,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-rpc-convert"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "jsonrpsee-types",
+ "reth-evm",
+ "reth-primitives-traits",
+ "revm-context",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "reth-rpc-engine-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8018,12 +8051,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -8047,9 +8081,9 @@ dependencies = [
  "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -8062,11 +8096,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -8086,8 +8121,8 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -8104,8 +8139,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -8118,8 +8153,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8133,26 +8168,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types-compat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
-dependencies = [
- "alloy-consensus",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "jsonrpsee-types",
- "reth-evm",
- "reth-primitives-traits",
- "revm-context",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "reth-stages"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8164,7 +8182,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "rayon",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -8197,8 +8215,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8224,8 +8242,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8238,8 +8256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8258,8 +8276,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8270,8 +8288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8294,8 +8312,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8310,8 +8328,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8328,8 +8346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8344,8 +8362,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8354,8 +8372,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "clap",
  "eyre",
@@ -8369,8 +8387,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8409,8 +8427,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8434,8 +8452,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8460,8 +8478,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8473,8 +8491,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8498,8 +8516,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8516,17 +8534,17 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth.git#ff5787da81b06665fbb9da242fe18f7213db9752"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "26.0.1"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2a493c73054a0f6635bad6e840cdbef34838e6e6186974833c901dff7dd709"
+checksum = "0eff49cb058b1100aba529a048655594d89f6b86cefd1b50b63facd2465b6a0e"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8543,9 +8561,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b395ee2212d44fcde20e9425916fee685b5440c3f8e01fabae8b0f07a2fd7f08"
+checksum = "b6a7d034cdf74c5f952ffc26e9667dd4285c86379ce1b1190b5d597c398a7565"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -8556,9 +8574,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "7.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b97b69d05651509b809eb7215a6563dc64be76a941666c40aabe597ab544d38"
+checksum = "199000545a2516f3fef7241e33df677275f930f56203ec4a586f7815e7fb5598"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -8572,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "7.0.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8f4f06a1c43bf8e6148509aa06a6c4d28421541944842b9b11ea1a6e53468f"
+checksum = "47db30cb6579fddb974462ea385d297ea57d0d13750fc1086d65166c4fb281eb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8588,9 +8606,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763eb5867a109a85f8e47f548b9d88c9143c0e443ec056742052f059fa32f4f1"
+checksum = "bbe1906ae0f5f83153a6d46da8791405eb30385b9deb4845c27b4a6802e342e8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8602,11 +8620,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5ecd19a5b75b862841113b9abdd864ad4b22e633810e11e6d620e8207e361d"
+checksum = "faffdc496bad90183f31a144ed122caefa4e74ffb02f57137dc8a94d20611550"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -8614,9 +8633,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "7.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b61f992beaa7a5fc3f5fcf79f1093624fa1557dc42d36baa42114c2d836b59"
+checksum = "844ecdeb61f8067a7ccb61e32c69d303fe9081b5f1e21e09a337c883f4dda1ad"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8633,9 +8652,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "7.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e4400a109a2264f4bf290888ac6d02432b6d5d070492b9dcf134b0c7d51354"
+checksum = "ee95fd546963e456ab9b615adc3564f64a801a49d9ebcdc31ff63ce3a601069c"
 dependencies = [
  "auto_impl",
  "either",
@@ -8651,9 +8670,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aabdffc06bdb434d9163e2d63b6fae843559afd300ea3fbeb113b8a0d8ec728"
+checksum = "8c42441fb05ac958e69262bd86841f8a91220e6794f9a0b99db1e1af51d8013e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -8669,9 +8688,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "22.0.1"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2481ef059708772cec0ce6bc4c84b796a40111612efb73b01adf1caed7ff9ac"
+checksum = "1776f996bb79805b361badd8b6326ac04a8580764aebf72b145620a6e21cf1c3"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8681,15 +8700,16 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d581e78c8f132832bd00854fb5bf37efd95a52582003da35c25cd2cbfc63849"
+checksum = "5c35a987086055a5cb368e080d1300ea853a3185b7bb9cdfebb8c05852cda24f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "arrayref",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
@@ -8701,7 +8721,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "rug",
- "secp256k1 0.31.0",
+ "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
@@ -8718,9 +8738,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6274928dd78f907103740b10800d3c0db6caeca391e75a159c168a1e5c78f8"
+checksum = "7f7bc9492e94ad3280c4540879d28d3fdbfbc432ebff60f17711740ebb4309ff"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -9089,6 +9109,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schnellru"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9140,9 +9172,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3dff2d01c9aa65c3186a45ff846bfea52cbe6de3b6320ed2a358d90dad0d76"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.9.1",
@@ -9268,7 +9300,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -9298,16 +9330,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9317,9 +9350,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9930,17 +9963,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -10047,7 +10082,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -10070,7 +10105,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -10257,9 +10292,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3927832d93178f979a970d26deed7b03510586e328f31b0f9ad7a73985b8332a"
+checksum = "ef54005d3d760186fd662dad4b7bb27ecd5531cdef54d1573ebd3f20a9205ed7"
 dependencies = [
  "loom",
  "once_cell",
@@ -10269,9 +10304,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c032d68a49d25d9012a864fef1c64ac17aee43c87e0477bf7301d8ae8bfea7b7"
+checksum = "5f9612d9503675b07b244922ea6f6f3cdd88c43add1b3498084613fc88cdf69d"
 dependencies = [
  "cc",
  "windows-targets 0.52.6",
@@ -11378,9 +11413,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,81 +13,81 @@ authors = ["Rollkit Contributors"]
 
 [workspace.dependencies]
 # Reth dependencies - Using the latest stable versions
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-network = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
-reth_ethereum_primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-network = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
+reth_ethereum_primitives = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0" }
 
 
 # Test dependencies
-reth-consensus = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8", default-features = false }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", version = "1.4.8", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0", default-features = false }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", version = "1.5.0", default-features = false }
 
 # Alloy dependencies
-alloy = { version = "1.0.9", features = [
+alloy = { version = "1.0.17", features = [
     "contract",
     "providers",
     "provider-http",
     "signers",
     "reqwest-rustls-tls",
 ], default-features = false }
-alloy-eips = { version = "1.0.9", default-features = false }
-alloy-network = { version = "1.0.9", default-features = false }
-alloy-provider = { version = "1.0.9", default-features = false }
-alloy-rpc-client = { version = "1.0.9", default-features = false }
-alloy-rpc-types = { version = "1.0.9", default-features = false }
-alloy-json-rpc = { version = "1.0.9", default-features = false }
-alloy-rpc-types-eth = { version = "1.0.9", default-features = false }
-alloy-rpc-types-engine = { version = "1.0.9", default-features = false }
-alloy-signer-local = { version = "1.0.9", features = ["mnemonic"] }
-alloy-primitives = { version = "1.1.0", default-features = false }
-alloy-consensus = { version = "1.0.9", default-features = false }
+alloy-eips = { version = "1.0.17", default-features = false }
+alloy-network = { version = "1.0.17", default-features = false }
+alloy-provider = { version = "1.0.17", default-features = false }
+alloy-rpc-client = { version = "1.0.17", default-features = false }
+alloy-rpc-types = { version = "1.0.17", default-features = false }
+alloy-json-rpc = { version = "1.0.17", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.17", default-features = false }
+alloy-rpc-types-engine = { version = "1.0.17", default-features = false }
+alloy-signer-local = { version = "1.0.17", features = ["mnemonic"] }
+alloy-primitives = { version = "1.2.0", default-features = false }
+alloy-consensus = { version = "1.0.17", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
-alloy-genesis = { version = "1.0.9", default-features = false }
+alloy-genesis = { version = "1.0.17", default-features = false }
 
 # Core dependencies
 eyre = "0.6"


### PR DESCRIPTION
Updates all reth dependencies from 1.4.8 to 1.5.0 and bumps alloy dependencies to maintain compatibility:
- reth: 1.4.8 -> 1.5.0
- alloy: 1.0.9 -> 1.0.17
- alloy-primitives: 1.1.0 -> 1.2.0

🤖 Generated with [Claude Code](https://claude.ai/code)

closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions for improved stability and compatibility. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->