### PR TITLE
chore(deps): cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
+checksum = "4195a29a4b87137b2bb02105e746102873bc03561805cf45c0e510c961f160e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -107,14 +107,14 @@ dependencies = [
  "num_enum",
  "proptest",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c6ad411efe0f49e0e99b9c7d8749a1eb55f6dbf74a1bc6953ab285b02c4f67"
+checksum = "ca3b746060277f3d7f9c36903bb39b593a741cb7afcb0044164c28f0e9b673f0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf397edad57b696501702d5887e4e14d7d0bbae9fbb6439e148d361f7254f45"
+checksum = "bf98679329fa708fa809ea596db6d974da892b068ad45e48ac1956f582edf946"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749b8449e4daf7359bdf1dabdba6ce424ff8b1bdc23bdb795661b2e991a08d87"
+checksum = "f562a81278a3ed83290e68361f2d1c75d018ae3b8589a314faf9303883e18ec9"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a198edb5172413c2300bdc591b4dec1caa643398bd7facc21d0925487dffcd8f"
+checksum = "ef2d6e0448bfd057a4438226b3d2fd547a0530fa4226217dfb1682d09f108bd4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fcbae2107f3f2df2b02bb7d9e81e8aa730ae371ca9dd7fd0c81c3d0cb78a452"
+checksum = "dc41384e9ab8c9b2fb387c52774d9d432656a28edcda1c2d4083e96051524518"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce138b29a2f8e7ed97c064af8359dfa6559c12cba5e821ae4eb93081a56557e"
+checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc30b0e20fcd0843834ecad2a716661c7b9d5aca2486f8e96b93d5246eb83e06"
+checksum = "12c454fcfcd5d26ed3b8cae5933cbee9da5f0b05df19b46d4bd4446d1f082565"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaeb681024cf71f5ca14f3d812c0a8d8b49f13f7124713538e66d74d3bfe6aff"
+checksum = "42d6d39eabe5c7b3d8f23ac47b0b683b99faa4359797114636c66e0743103d05"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ad273e1c55cc481889b4130e82860e33624e6969e9a08854e0f3ebe659295"
+checksum = "3704fa8b7ba9ba3f378d99b3d628c8bc8c2fc431b709947930f154e22a8368b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc164acf8c41c756e76c7aea3be8f0fb03f8a3ef90a33e3ddcea5d1614d8779"
+checksum = "08800e8cbe70c19e2eb7cf3d7ff4b28bdd9b3933f8e1c8136c7d910617ba03bf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670d155c3e35bcaa252ca706a2757a456c56aa71b80ad1539d07d49b86304e78"
+checksum = "ae68457a2c2ead6bd7d7acb5bf5f1623324b1962d4f8e7b0250657a3c3ab0a0b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c44d31bcb9afad460915fe1fba004a2af5a07a3376c307b9bdfeec3678c209"
+checksum = "162301b5a57d4d8f000bf30f4dcb82f9f468f3e5e846eeb8598dd39e7886932c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -479,7 +479,6 @@ dependencies = [
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest 0.12.22",
@@ -489,16 +488,15 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba2cf3d3c6ece87f1c6bb88324a997f28cf0ad7e98d5e0b6fa91c4003c30916"
+checksum = "6cd8ca94ae7e2b32cc3895d9981f3772aab0b4756aa60e9ed0bcfee50f0e1328"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -509,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ce874dde17cc749f1aa8883e0c1431ddda6ba6dd9c9eb9b31d1fb0a6023830"
+checksum = "e7bff682e76f3f72e9ddc75e54a1bd1db5ce53cbdf2cce2d63a3a981437f78f5"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -521,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e80e2ffa56956a92af375df1422b239fde6552bd222dfeaeb39f07949060fa"
+checksum = "9f3ff6a778ebda3deaed9af17930d678611afe1effa895c4260b61009c314f82"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -533,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5b22062142ce3b2ed3374337d4b343437e5de6959397f55d2c9fe2c2ce0162"
+checksum = "076b47e834b367d8618c52dd0a0d6a711ddf66154636df394805300af4923b8a"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -544,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438a7a3a5c5d11877787e324dd1ffd9ab82314ca145513ebe8d12257cbfefb5b"
+checksum = "48f39da9b760e78fc3f347fba4da257aa6328fb33f73682b26cc0a6874798f7d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -562,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f53a2a78b44582e0742ab96d5782842d9b90cebf6ef6ccd8be864ae246fdd0f"
+checksum = "94a2a86ad7b7d718c15e79d0779bd255561b6b22968dc5ed2e7c0fbc43bb55fe"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -572,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7041c3fd4dcd7af95e86280944cc33b4492ac2ddbe02f84079f8019742ec2857"
+checksum = "4ba838417c42e8f1fe5eb4f4bbfacb7b5d4b9e615b8d2e831b921e04bf0bed62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -588,14 +586,14 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391e59f81bacbffc7bddd2da3a26d6eec0e2058e9237c279e9b1052bdf21b49e"
+checksum = "2c2f847e635ec0be819d06e2ada4bcc4e4204026a83c4bfd78ae8d550e027ae7"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -609,14 +607,15 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3f327d4cd140eca2c6c27c82c381aba6fa6a32cbb697c146b5607532f82167"
+checksum = "fb1c9b23cedf70aeb99ea9f16b78cdf902f524e227922fb340e3eb899ebe96dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -629,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d96238f37e8a72dcf2cf6bead4c4f91dec1c0720b12be10558406e1633a804"
+checksum = "6fc58180302a94c934d455eeedb3ecb99cdc93da1dbddcdbbdb79dd6fe618b2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -643,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45d00db47a280d0a6e498b6e63344bccd9485d8860d2e2f06b680200c37ebc2"
+checksum = "0f9f089d78bb94148e0fcfda087d4ce5fd35a7002847b5e90610c0fcb140f7b4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -655,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea08bc854235d4dff08fd57df8033285c11b8d7548b20c6da218194e7e6035f"
+checksum = "ae699248d02ade9db493bbdae61822277dc14ae0f82a5a4153203b60e34422a6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -667,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb3759f85ef5f010a874d9ebd5ee6ce01cac65211510863124e0ebac6552db0"
+checksum = "3cf7d793c813515e2b627b19a15693960b3ed06670f9f66759396d06ebe5747b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -682,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d95902d29e1290809e1c967a1e974145b44b78f6e3e12fc07a60c1225e3df0"
+checksum = "51a424bc5a11df0d898ce0fd15906b88ebe2a6e4f17a514b51bc93946bb756bd"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -768,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdf4b7fc58ebb2605b2fc5a33dae5cf15527ea70476978351cc0db1c596ea93"
+checksum = "4f317d20f047b3de4d9728c556e2e9a92c9a507702d2016424cd8be13a74ca5e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -791,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4b0f3a9c28bcd3761504d9eb3578838d6d115c8959fc1ea05f59a3a8f691af"
+checksum = "ff084ac7b1f318c87b579d221f11b748341d68b9ddaa4ffca5e62ed2b8cfefb4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -806,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758edb7c266374374e001c50fb1ea89cb5ed48d47ffbf297599f2a557804dd3b"
+checksum = "edb099cdad8ed2e6a80811cdf9bbf715ebf4e34c981b4a6e2d1f9daacbf8b218"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -826,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5596b913d1299ee37a9c1bb5118b2639bf253dc1088957bdf2073ae63a6fdfa"
+checksum = "0e915e1250dc129ad48d264573ccd08e4716fdda564a772fd217875b8459aff9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -864,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bf2869e66904b2148c809e7a75e23ca26f5d7b46663a149a1444fb98a69d1d"
+checksum = "1154c8187a5ff985c95a8b2daa2fedcf778b17d7668e5e50e556c4ff9c881154"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -1282,9 +1281,9 @@ checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "brotli",
  "flate2",
@@ -1619,17 +1618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
-dependencies = [
- "memchr",
- "regex-automata 0.4.9",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,9 +1725,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -1820,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1830,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1842,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1906,18 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2035,9 +2011,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -2541,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2594,12 +2570,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3149,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -3445,7 +3415,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3496,7 +3466,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -3514,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3789,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
@@ -4248,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4649,9 +4619,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -4897,12 +4867,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4911,7 +4880,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5062,12 +5031,13 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
+ "cfg-if",
  "proptest",
  "ruint",
  "serde",
@@ -5101,9 +5071,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.9"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8719d9b783b29cfa1cf8d591b894805786b9ab4940adc700a57fd0d5b721cf5"
+checksum = "18986c5cf19a790b8b9e8c856a950b48ed6dd6a0259d0efd5f5c9bebbba1fc3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5119,9 +5089,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.9"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4559d84f079b3fdfd01e4ee0bb118025e92105fbb89736f5d77ab3ca261698"
+checksum = "814d2b82a6d0b973afc78e797a74818165f257041b9173016dccbe3647f8b1da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5138,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "8.0.1"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84de364c50baff786d09ab18d3cdd4f5ff23612e96c00a96b65de3c470f553df"
+checksum = "ee9ba9cab294a5ed02afd1a1060220762b3c52911acab635db33822e93f7276d"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -5965,7 +5935,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -6034,7 +6004,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -6045,8 +6015,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6069,8 +6039,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6100,8 +6070,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6120,8 +6090,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6134,8 +6104,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6172,6 +6142,7 @@ dependencies = [
  "reth-discv5",
  "reth-downloaders",
  "reth-ecies",
+ "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
@@ -6193,6 +6164,7 @@ dependencies = [
  "reth-provider",
  "reth-prune",
  "reth-prune-types",
+ "reth-revm",
  "reth-stages",
  "reth-stages-types",
  "reth-static-file",
@@ -6212,8 +6184,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6222,8 +6194,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6241,8 +6213,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6261,8 +6233,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6272,8 +6244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6287,8 +6259,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6300,8 +6272,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6312,8 +6284,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6331,13 +6303,14 @@ dependencies = [
  "reth-tracing",
  "ringbuffer",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "reth-db"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6354,7 +6327,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "rustc-hash 2.1.1",
- "strum 0.27.1",
+ "strum 0.27.2",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.12",
@@ -6362,8 +6335,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6390,8 +6363,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6419,8 +6392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6434,8 +6407,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6460,8 +6433,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6484,8 +6457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6508,8 +6481,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6538,8 +6511,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6569,8 +6542,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6591,8 +6564,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6616,8 +6589,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "futures",
  "pin-project",
@@ -6639,8 +6612,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6676,6 +6649,7 @@ dependencies = [
  "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
+ "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
  "schnellru",
@@ -6686,8 +6660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6713,8 +6687,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6729,8 +6703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6744,8 +6718,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6768,8 +6742,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6779,8 +6753,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6808,8 +6782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6832,8 +6806,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -6869,67 +6843,30 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "backon",
  "clap",
  "eyre",
- "futures",
- "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
  "reth-db",
- "reth-db-api",
- "reth-downloaders",
- "reth-errors",
- "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-api",
- "reth-network-p2p",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
- "reth-node-events",
  "reth-node-metrics",
- "reth-payload-builder",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-revm",
- "reth-stages",
- "reth-static-file",
- "reth-tasks",
  "reth-tracing",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
- "serde_json",
- "similar-asserts",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6944,8 +6881,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6962,8 +6899,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6976,8 +6913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7003,8 +6940,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7021,8 +6958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7031,8 +6968,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7054,8 +6991,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7073,8 +7010,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7086,8 +7023,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7104,8 +7041,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7142,8 +7079,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7156,8 +7093,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "serde",
  "serde_json",
@@ -7166,8 +7103,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7194,8 +7131,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "bytes",
  "futures",
@@ -7214,8 +7151,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7231,8 +7168,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "bindgen",
  "cc",
@@ -7240,8 +7177,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "futures",
  "metrics",
@@ -7252,16 +7189,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7274,8 +7211,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7329,11 +7266,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-admin",
+ "alloy-rpc-types-eth",
  "auto_impl",
  "derive_more",
  "enr",
@@ -7352,8 +7291,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7374,8 +7313,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7389,8 +7328,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7403,8 +7342,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7420,8 +7359,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7444,8 +7383,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7482,6 +7421,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
+ "reth-node-ethstats",
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
@@ -7508,8 +7448,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7529,6 +7469,7 @@ dependencies = [
  "reth-db",
  "reth-discv4",
  "reth-discv5",
+ "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
  "reth-net-nat",
@@ -7548,7 +7489,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "shellexpand",
- "strum 0.27.1",
+ "strum 0.27.2",
  "thiserror 2.0.12",
  "toml",
  "tracing",
@@ -7559,15 +7500,17 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
+ "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
  "reth-chainspec",
  "reth-consensus",
+ "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
@@ -7585,6 +7528,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tracing",
@@ -7594,9 +7538,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-node-ethstats"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "chrono",
+ "futures-util",
+ "reth-chain-state",
+ "reth-network-api",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-transaction-pool",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "reth-node-events"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7619,8 +7587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -7640,8 +7608,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7653,8 +7621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7672,8 +7640,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7692,8 +7660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7704,8 +7672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7723,8 +7691,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7733,8 +7701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -7747,8 +7715,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7780,8 +7748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7818,15 +7786,15 @@ dependencies = [
  "reth-trie-db",
  "revm-database",
  "revm-state",
- "strum 0.27.1",
+ "strum 0.27.2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7853,8 +7821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7867,8 +7835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7880,8 +7848,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7919,7 +7887,6 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -7956,8 +7923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7984,8 +7951,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8022,15 +7989,17 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "alloy-signer",
  "jsonrpsee-types",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
  "revm-context",
@@ -8039,8 +8008,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8069,8 +8038,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8114,12 +8083,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -8157,8 +8127,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -8171,8 +8141,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8182,13 +8152,13 @@ dependencies = [
  "reth-errors",
  "reth-network-api",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-stages"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8233,8 +8203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8260,8 +8230,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8274,8 +8244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8294,20 +8264,20 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "clap",
  "derive_more",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8330,8 +8300,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8346,8 +8316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8364,8 +8334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8380,8 +8350,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8390,8 +8360,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "clap",
  "eyre",
@@ -8405,8 +8375,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8445,8 +8415,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8470,8 +8440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8496,8 +8466,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8509,8 +8479,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8534,8 +8504,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8551,18 +8521,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-trie-sparse-parallel"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "rayon",
+ "reth-execution-errors",
+ "reth-trie-common",
+ "reth-trie-sparse",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "reth-zstd-compressors"
-version = "1.5.0"
-source = "git+https://github.com/paradigmxyz/reth.git#60940dd243918a1ba55f5cce5046a443bc75611d"
+version = "1.5.1"
+source = "git+https://github.com/paradigmxyz/reth.git#03ceac7e79d4e8151c5e12f636c48da2525dff02"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "27.0.1"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eff49cb058b1100aba529a048655594d89f6b86cefd1b50b63facd2465b6a0e"
+checksum = "70a84455f03d3480d4ed2e7271c15f2ec95b758e86d57cb8d258a8ff1c22e9a4"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8579,9 +8565,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a7d034cdf74c5f952ffc26e9667dd4285c86379ce1b1190b5d597c398a7565"
+checksum = "7a685758a4f375ae9392b571014b9779cfa63f0d8eb91afb4626ddd958b23615"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -8592,9 +8578,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "8.0.1"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199000545a2516f3fef7241e33df677275f930f56203ec4a586f7815e7fb5598"
+checksum = "a990abf66b47895ca3e915d5f3652bb7c6a4cff6e5351fdf0fc2795171fd411c"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -8608,9 +8594,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47db30cb6579fddb974462ea385d297ea57d0d13750fc1086d65166c4fb281eb"
+checksum = "a303a93102fceccec628265efd550ce49f2817b38ac3a492c53f7d524f18a1ca"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8624,9 +8610,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe1906ae0f5f83153a6d46da8791405eb30385b9deb4845c27b4a6802e342e8"
+checksum = "7db360729b61cc347f9c2f12adb9b5e14413aea58778cf9a3b7676c6a4afa115"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8638,9 +8624,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faffdc496bad90183f31a144ed122caefa4e74ffb02f57137dc8a94d20611550"
+checksum = "b8500194cad0b9b1f0567d72370795fd1a5e0de9ec719b1607fa1566a23f039a"
 dependencies = [
  "auto_impl",
  "either",
@@ -8651,9 +8637,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "8.0.1"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844ecdeb61f8067a7ccb61e32c69d303fe9081b5f1e21e09a337c883f4dda1ad"
+checksum = "03c35a17a38203976f97109e20eccf6732447ce6c9c42973bae42732b2e957ff"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8670,9 +8656,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "8.0.1"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee95fd546963e456ab9b615adc3564f64a801a49d9ebcdc31ff63ce3a601069c"
+checksum = "e69abf6a076741bd5cd87b7d6c1b48be2821acc58932f284572323e81a8d4179"
 dependencies = [
  "auto_impl",
  "either",
@@ -8688,9 +8674,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.26.0"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c42441fb05ac958e69262bd86841f8a91220e6794f9a0b99db1e1af51d8013e"
+checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -8706,9 +8692,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "23.0.0"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1776f996bb79805b361badd8b6326ac04a8580764aebf72b145620a6e21cf1c3"
+checksum = "d95c4a9a1662d10b689b66b536ddc2eb1e89f5debfcabc1a2d7b8417a2fa47cd"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8718,9 +8704,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "24.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c35a987086055a5cb368e080d1300ea853a3185b7bb9cdfebb8c05852cda24f"
+checksum = "b68d54a4733ac36bd29ee645c3c2e5e782fb63f199088d49e2c48c64a9fedc15"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8756,9 +8742,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7bc9492e94ad3280c4540879d28d3fdbfbc432ebff60f17711740ebb4309ff"
+checksum = "106fec5c634420118c7d07a6c37110186ae7f23025ceac3a5dbe182eea548363"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -8977,22 +8963,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
@@ -9063,9 +9049,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -9128,9 +9114,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -9314,9 +9300,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -9358,7 +9344,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9508,27 +9494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console",
- "serde",
- "similar",
-]
-
-[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9654,11 +9619,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -9676,14 +9641,13 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.104",
 ]
 
@@ -9819,7 +9783,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -9981,9 +9945,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10051,6 +10015,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -10228,8 +10193,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -10322,9 +10285,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9612d9503675b07b244922ea6f6f3cdd88c43add1b3498084613fc88cdf69d"
+checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
  "windows-targets 0.52.6",
@@ -10785,14 +10748,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.1",
+ "webpki-root-certs 1.0.2",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10803,14 +10766,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11369,9 +11332,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -11436,7 +11399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]


### PR DESCRIPTION
weekly
`cargo

update`
Updating

git
repository

`https://github.com/paradigmxyz/reth.git`
Locking

167
packages

to
latest

compatible
versions

Updating
alloy-chains

v0.2.4
->

v0.2.5
Updating

alloy-consensus
v1.0.17

->
v1.0.20

Updating
alloy-consensus-any

v1.0.17
->

v1.0.20
Updating

alloy-eips
v1.0.17

->
v1.0.20

Updating
alloy-evm

v0.13.0
->

v0.14.0
Updating

alloy-genesis
v1.0.17

->
v1.0.20

Updating
alloy-hardforks

v0.2.11
->

v0.2.12
Updating

alloy-json-rpc
v1.0.17

->
v1.0.20

Updating
alloy-network

v1.0.17
->

v1.0.20
Updating

alloy-network-primitives
v1.0.17

->
v1.0.20

Updating
alloy-provider

v1.0.17
->

v1.0.20
Updating

alloy-pubsub
v1.0.17

->
v1.0.20

Updating
alloy-rpc-client

v1.0.17
->

v1.0.20
Updating

alloy-rpc-types
v1.0.17

->
v1.0.20

Updating
alloy-rpc-types-admin

v1.0.17
->

v1.0.20
Updating

alloy-rpc-types-anvil
v1.0.17

->
v1.0.20

Updating
alloy-rpc-types-any

v1.0.17
->

v1.0.20
Updating

alloy-rpc-types-beacon
v1.0.17

->
v1.0.20

Updating
alloy-rpc-types-debug

v1.0.17
->

v1.0.20
Updating

alloy-rpc-types-engine
v1.0.17

->
v1.0.20

Updating
alloy-rpc-types-eth

v1.0.17
->

v1.0.20
Updating

alloy-rpc-types-mev
v1.0.17

->
v1.0.20

Updating
alloy-rpc-types-trace

v1.0.17
->

v1.0.20
Updating

alloy-rpc-types-txpool
v1.0.17

->
v1.0.20

Updating
alloy-serde

v1.0.17
->

v1.0.20
Updating

alloy-signer
v1.0.17

->
v1.0.20

Updating
alloy-signer-local

v1.0.17
->

v1.0.20
Updating

alloy-transport
v1.0.17

->
v1.0.20

Updating
alloy-transport-http

v1.0.17
->

v1.0.20
Updating

alloy-transport-ipc
v1.0.17

->
v1.0.20

Updating
alloy-transport-ws

v1.0.17
->

v1.0.20
Updating

alloy-tx-macros
v1.0.17

->
v1.0.20

Removing
bstr

v1.12.0
Updating

castaway
v0.2.3

->
v0.2.4

Updating
clap

v4.5.40
->

v4.5.41
Updating

clap_builder
v4.5.40

->
v4.5.41

Updating
clap_derive

v4.5.40
->

v4.5.41
Removing

console
v0.15.11

Updating
curve25519-dalek

v4.1.3
->

v4.2.0
Updating

ed25519-dalek
v2.1.1

->
v2.2.0

Removing
encode_unicode

v1.0.0
Updating

fiat-crypto
v0.2.9

->
v0.3.0

Updating
h2

v0.3.26
->

v0.3.27
Updating

hyper-util
v0.1.14

->
v0.1.15

Updating
notify

v8.0.0
->

v8.1.0
Updating

nybbles
v0.4.0

->
v0.4.1

Updating
op-revm

v8.0.1
->

v8.0.2
Updating

reth-basic-payload-builder
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-chain-state
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-chainspec
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-cli
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-cli-commands
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-cli-runner
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-cli-util
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-codecs
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-codecs-derive
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-config
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-consensus
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-consensus-common
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-consensus-debug-client
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-db
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-db-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-db-common
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-db-models
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-discv4
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-discv5
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-dns-discovery
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-downloaders
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ecies
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-engine-local
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-engine-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-engine-service
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-engine-tree
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-engine-util
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-era
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-era-downloader
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-era-utils
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-errors
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-eth-wire
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-eth-wire-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum-cli
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum-consensus
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum-engine-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum-forks
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum-payload-builder
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ethereum-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-etl
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-evm
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-evm-ethereum
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-execution-errors
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-execution-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-exex
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-exex-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-fs-util
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-invalid-block-hooks
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-ipc
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-libmdbx
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-mdbx-sys
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-metrics
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-net-banlist
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-net-nat
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-network
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-network-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-network-p2p
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-network-peers
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-network-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-nippy-jar
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-builder
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-core
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-ethereum
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-events
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-metrics
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-node-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-optimism-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-payload-builder
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-payload-builder-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-payload-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-payload-validator
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-primitives
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-primitives-traits
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-provider
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-prune
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-prune-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-revm
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-builder
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-convert
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-engine-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-eth-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-eth-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-layer
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-rpc-server-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-stages
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-stages-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-stages-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-static-file
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-static-file-types
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-storage-api
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-storage-errors
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-tasks
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-testing-utils
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-tokio-util
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-tracing
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-transaction-pool
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-trie
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-trie-common
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-trie-db
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-trie-parallel
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

reth-trie-sparse
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Adding

reth-trie-sparse-parallel
v1.5.1

(https://github.com/paradigmxyz/reth.git#4767e1c2) Updating

reth-zstd-compressors
v1.5.0

(https://github.com/paradigmxyz/reth.git#60940dd2) ->

#4767e1c2
Updating

revm
v27.0.1

->
v27.0.2

Updating
revm-bytecode

v6.0.0
->

v6.0.1
Updating

revm-context
v8.0.1

->
v8.0.2

Updating
revm-context-interface

v8.0.0
->

v8.0.1
Updating

revm-database
v7.0.0

->
v7.0.1

Updating
revm-database-interface

v7.0.0
->

v7.0.1
Updating

revm-handler
v8.0.1

->
v8.0.2

Updating
revm-inspector

v8.0.1
->

v8.0.2
Updating

revm-inspectors
v0.26.0

->
v0.26.5

Updating
revm-interpreter

v23.0.0
->

v23.0.1
Updating

revm-state
v7.0.0

->
v7.0.1

Updating
rustls

v0.23.28
->

v0.23.29
Updating

rustls-webpki
v0.103.3

->
v0.103.4

Updating
schemars

v1.0.3
->

v1.0.4
Removing

similar
v2.7.0

Removing
similar-asserts

v1.7.0
Updating

tokio
v1.46.0

->
v1.46.1

Updating
winnow

v0.7.11
->

v0.7.12
note:

pass
`--verbose`

to
see

4
unchanged

dependencies
behind

latest

## Description

<!-- Please include a summary of the changes and the related issue. -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues

<!-- Link to any related issues -->
Fixes #(issue)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR here -->