### PR TITLE
chore: add curl to cross docker image

### DIFF
--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -3,6 +3,7 @@ FROM ghcr.io/cross-rs/cross:main
 # Install ARM64 cross-compilation toolchain
 RUN apt-get update && \
     apt-get install -y \
+        curl \
         gcc-aarch64-linux-gnu \
         g++-aarch64-linux-gnu \
         libc6-dev-arm64-cross \

--- a/Dockerfile.cross-x86_64
+++ b/Dockerfile.cross-x86_64
@@ -4,6 +4,7 @@ FROM ghcr.io/cross-rs/cross:main
 RUN apt-get update && \
     apt-get install -y \
         build-essential \
+        curl \
         pkg-config \
         libclang-dev \
         clang && \


### PR DESCRIPTION
The change adds the curl utility to the cross-platform Docker image, which is commonly needed for health checks, debugging, or making HTTP requests from within the container.
