### PR TITLE
build: bump ubuntu in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN cargo build --profile $BUILD_PROFILE --bin ev-reth --manifest-path bin/ev-re
 RUN ls -la /app/target/$BUILD_PROFILE/ev-reth
 RUN cp /app/target/$BUILD_PROFILE/ev-reth /ev-reth
 
-FROM ubuntu:22.04 AS runtime
+FROM ubuntu:24.04 AS runtime
 
 RUN apt-get update && \
     apt-get install -y ca-certificates curl jq libssl-dev pkg-config strace && \


### PR DESCRIPTION
## Description

I was getting the following using a too old version of ubuntu

```
/usr/local/bin/ev-reth: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/ev-reth)
/usr/local/bin/ev-reth: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.36' not found (required by /usr/local/bin/ev-reth)
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues

<!-- Link to any related issues -->
Fixes #(issue)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR here -->