### PR TITLE
chore: Disable default features on some crates to unblock SP1 work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6343,8 +6343,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6367,8 +6367,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6398,8 +6398,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6418,8 +6418,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6432,8 +6432,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6513,8 +6513,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6523,8 +6523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6542,8 +6542,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6562,8 +6562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6573,8 +6573,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6588,8 +6588,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6601,8 +6601,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6613,8 +6613,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6639,8 +6639,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6665,8 +6665,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6693,8 +6693,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6723,8 +6723,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6738,8 +6738,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6764,8 +6764,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6788,8 +6788,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6812,8 +6812,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6847,8 +6847,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6904,8 +6904,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6935,8 +6935,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6957,8 +6957,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6982,8 +6982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "futures",
  "pin-project",
@@ -7005,8 +7005,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7059,8 +7059,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7087,8 +7087,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7103,8 +7103,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7118,8 +7118,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7140,8 +7140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7151,8 +7151,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7180,8 +7180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7204,8 +7204,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7244,8 +7244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "clap",
  "eyre",
@@ -7266,8 +7266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7282,8 +7282,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7300,8 +7300,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7314,8 +7314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7343,8 +7343,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7363,8 +7363,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7373,8 +7373,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7396,8 +7396,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7417,8 +7417,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7430,8 +7430,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7448,8 +7448,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7486,8 +7486,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7500,8 +7500,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "serde",
  "serde_json",
@@ -7510,8 +7510,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7537,8 +7537,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "bytes",
  "futures",
@@ -7557,8 +7557,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -7573,8 +7573,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -7582,8 +7582,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "futures",
  "metrics",
@@ -7594,16 +7594,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7616,8 +7616,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7671,8 +7671,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7696,8 +7696,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7719,8 +7719,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7734,8 +7734,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7748,8 +7748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7765,8 +7765,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7789,8 +7789,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7857,8 +7857,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7909,8 +7909,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -7947,8 +7947,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7971,8 +7971,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7995,8 +7995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8016,8 +8016,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8028,8 +8028,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8047,8 +8047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8068,8 +8068,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8080,8 +8080,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8100,8 +8100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8110,8 +8110,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -8123,8 +8123,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8156,8 +8156,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8201,8 +8201,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8229,8 +8229,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8238,13 +8238,14 @@ dependencies = [
  "modular-bitfield",
  "reth-codecs",
  "serde",
+ "strum 0.27.2",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8256,8 +8257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8335,8 +8336,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8363,8 +8364,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8402,8 +8403,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -8423,8 +8424,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8453,8 +8454,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8497,8 +8498,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8544,8 +8545,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -8558,8 +8559,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8574,8 +8575,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,8 +8623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8649,8 +8650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8663,8 +8664,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8683,8 +8684,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8695,8 +8696,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8718,8 +8719,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8734,8 +8735,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8752,8 +8753,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8768,8 +8769,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8778,8 +8779,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "clap",
  "eyre",
@@ -8793,8 +8794,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -8807,8 +8808,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8850,8 +8851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8875,8 +8876,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8901,8 +8902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8914,8 +8915,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8939,8 +8940,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8958,8 +8959,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8976,8 +8977,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.3#42197415102b7a20be42e4fe919f024b81ceb55b"
+version = "1.8.4"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,68 +20,68 @@ repository = "https://github.com/evstack/ev-reth"
 authors = ["Evolve Stack Contributors"]
 
 [workspace.dependencies]
-# Reth dependencies - Using v1.8.3 stable
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
-reth-network = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.3" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-node-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.3" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.3" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3" }
+# Reth dependencies - Using v1.8.4 stable
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-node = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
+reth-network = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-network-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.4" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.4" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.4" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", default-features = false, tag = "v1.8.4" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
 
 ev-revm = { path = "crates/ev-revm" }
 
 
 # Consensus dependencies
-reth-consensus = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
 
 # Test dependencies
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.3", default-features = false }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4", default-features = false }
 
 revm = { version = "29.0.1", default-features = false }
 revm-context-interface = { version = "10.2.0", default-features = false }
@@ -91,7 +91,7 @@ alloy = { version = "=1.0.37", default-features = false, features = [
   "sol-types",
 ] }
 # Alloy dependencies
-# Alloy family versions aligned to 1.0.37 compatibility (reth v1.8.3)
+# Alloy family versions aligned to 1.0.37 compatibility (reth v1.8.4)
 alloy-evm = { version = "0.21.3", default-features = false }
 alloy-eips = { version = "1.0.37", default-features = false }
 alloy-network = { version = "1.0.37", default-features = false }


### PR DESCRIPTION
The Interop team needs to import portions of the evolve code into the SP1 context to address recent changes in FeeHandler.

To enable this, several default features were disabled on specific crates to ensure no C-deps are pulled in, which can't be compiled by the SP1 toolchain.