### PR TITLE
fix: decode payload transactions with EIP-2718 exact format

### DIFF
--- a/crates/node/src/payload_service.rs
+++ b/crates/node/src/payload_service.rs
@@ -223,7 +223,7 @@ where
                 .unwrap_or_default()
                 .into_iter()
                 .filter_map(|tx_bytes| {
-                    match TransactionSigned::network_decode(&mut tx_bytes.as_ref()) {
+                    match TransactionSigned::decode_2718_exact(tx_bytes.as_ref()) {
                         Ok(tx) => Some(tx),
                         Err(err) => {
                             tracing::warn!(


### PR DESCRIPTION
## Summary

- Replace `TransactionSigned::network_decode` with `TransactionSigned::decode_2718_exact` in the Engine API payload builder path
- Align builder-time decoding with executor-time validation, which already uses `decode_2718_exact` when processing `ExecutionData`

## Background

Engine API (`engine_newPayload*`) specifies transactions as opaque EIP-2718 encoded bytes. The previous `network_decode` expects the devp2p wire format, which wraps typed transactions in an RLP string header (length prefix + opaque payload). On EIP-2718 bytes, this wrapping is absent — so typed transactions (EIP-1559, EIP-2930, and the EvNode types `0x76` / `0x78`) were silently dropped by the `filter_map`, logging a warning and continuing to build without them.

The executor uses `TxTy::<EvPrimitives>::decode_2718_exact` when processing the same transactions via `ExecutionData` (`crates/node/src/executor.rs:387`). Build-time acceptance must match validation-time acceptance to avoid consensus divergence.

Addresses the CodeRabbit review comment on #207.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated transaction decoding mechanism for payload processing. No change to user-facing behavior; transaction validation and error handling remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->