### PR TITLE
fix: use Display formatting for tracing fields instead of Debug formatting

### DIFF
--- a/crates/ev-precompiles/src/mint.rs
+++ b/crates/ev-precompiles/src/mint.rs
@@ -144,16 +144,16 @@ impl MintPrecompile {
         caller: Address,
     ) -> MintPrecompileResult<()> {
         if caller == self.admin {
-            tracing::debug!(target: "mint_precompile", caller = %caller, "authorization granted: admin");
+            tracing::debug!(target: "mint_precompile", %caller, "authorization granted: admin");
             return Ok(());
         }
 
         let allowlisted = Self::is_allowlisted(internals, caller)?;
         if allowlisted {
-            tracing::debug!(target: "mint_precompile", caller = %caller, "authorization granted: allowlist");
+            tracing::debug!(target: "mint_precompile", %caller, "authorization granted: allowlist");
             Ok(())
         } else {
-            tracing::warn!(target: "mint_precompile", caller = %caller, "authorization denied: not admin and not allowlisted");
+            tracing::warn!(target: "mint_precompile", %caller, "authorization denied: not admin and not allowlisted");
             Err(MintPrecompileError::halt_static("unauthorized caller"))
         }
     }
@@ -171,7 +171,7 @@ impl MintPrecompile {
         let allowlisted = !raw_value.is_zero();
         tracing::debug!(
             target: "mint_precompile",
-            addr = %addr,
+            %addr,
             slot = %key,
             value = %raw_value,
             allowlisted,
@@ -215,7 +215,7 @@ impl Precompile for MintPrecompile {
 
         tracing::info!(
             target: "mint_precompile",
-            caller = %caller,
+            %caller,
             gas = gas_limit,
             calldata_len = data_len,
             "mint precompile call invoked"

--- a/crates/ev-precompiles/src/mint.rs
+++ b/crates/ev-precompiles/src/mint.rs
@@ -144,16 +144,16 @@ impl MintPrecompile {
         caller: Address,
     ) -> MintPrecompileResult<()> {
         if caller == self.admin {
-            tracing::debug!(target: "mint_precompile", ?caller, "authorization granted: admin");
+            tracing::debug!(target: "mint_precompile", caller = %caller, "authorization granted: admin");
             return Ok(());
         }
 
         let allowlisted = Self::is_allowlisted(internals, caller)?;
         if allowlisted {
-            tracing::debug!(target: "mint_precompile", ?caller, "authorization granted: allowlist");
+            tracing::debug!(target: "mint_precompile", caller = %caller, "authorization granted: allowlist");
             Ok(())
         } else {
-            tracing::warn!(target: "mint_precompile", ?caller, "authorization denied: not admin and not allowlisted");
+            tracing::warn!(target: "mint_precompile", caller = %caller, "authorization denied: not admin and not allowlisted");
             Err(MintPrecompileError::halt_static("unauthorized caller"))
         }
     }
@@ -171,7 +171,7 @@ impl MintPrecompile {
         let allowlisted = !raw_value.is_zero();
         tracing::debug!(
             target: "mint_precompile",
-            ?addr,
+            addr = %addr,
             slot = %key,
             value = %raw_value,
             allowlisted,
@@ -215,7 +215,7 @@ impl Precompile for MintPrecompile {
 
         tracing::info!(
             target: "mint_precompile",
-            ?caller,
+            caller = %caller,
             gas = gas_limit,
             calldata_len = data_len,
             "mint precompile call invoked"

--- a/crates/node/src/builder.rs
+++ b/crates/node/src/builder.rs
@@ -52,7 +52,7 @@ where
         if let Some((sink, activation)) = config.base_fee_redirect_settings() {
             info!(
                 target: "ev-reth",
-                fee_sink = ?sink,
+                fee_sink = %sink,
                 activation_height = activation,
                 "Base fee redirect enabled via chainspec"
             );
@@ -69,7 +69,7 @@ where
     #[instrument(skip(self, attributes), fields(
         parent_hash = %attributes.parent_hash,
         tx_count = attributes.transactions.len(),
-        gas_limit = ?attributes.gas_limit,
+        gas_limit = attributes.gas_limit.unwrap_or(0),
         duration_ms = tracing::field::Empty,
     ))]
     pub async fn build_payload(
@@ -118,7 +118,7 @@ where
                 suggested_fee_recipient = sink;
                 info!(
                     target: "ev-reth",
-                    fee_sink = ?sink,
+                    fee_sink = %sink,
                     block_number,
                     "Suggested fee recipient missing; defaulting to base-fee sink"
                 );
@@ -170,10 +170,10 @@ where
 
             match builder.execute_transaction(recovered_tx) {
                 Ok(gas_used) => {
-                    debug!(gas_used = ?gas_used, "transaction executed successfully");
+                    debug!(gas_used, "transaction executed successfully");
                 }
                 Err(err) => {
-                    tracing::warn!(error = ?err, tx_hash = %tx.tx_hash(), "transaction execution failed");
+                    tracing::warn!(error = %err, tx_hash = %tx.tx_hash(), "transaction execution failed");
                 }
             }
         }
@@ -192,7 +192,7 @@ where
 
         info!(
             block_number = sealed_block.number,
-            block_hash = ?sealed_block.hash(),
+            block_hash = %sealed_block.hash(),
             tx_count = sealed_block.transaction_count(),
             gas_used = sealed_block.gas_used,
             "built block"
@@ -221,13 +221,13 @@ where
     let config = match EvolvePayloadBuilderConfig::from_chain_spec(&chain_spec) {
         Ok(config) => config,
         Err(err) => {
-            tracing::warn!(target: "ev-reth", error = ?err, "Failed to parse chainspec extras");
+            tracing::warn!(target: "ev-reth", error = %err, "Failed to parse chainspec extras");
             return None;
         }
     };
 
     if let Err(err) = config.validate() {
-        tracing::warn!(target: "ev-reth", error = ?err, "Invalid evolve payload builder configuration");
+        tracing::warn!(target: "ev-reth", error = %err, "Invalid evolve payload builder configuration");
         return None;
     }
 

--- a/crates/node/src/builder.rs
+++ b/crates/node/src/builder.rs
@@ -170,7 +170,7 @@ where
 
             match builder.execute_transaction(recovered_tx) {
                 Ok(gas_used) => {
-                    debug!(gas_used, "transaction executed successfully");
+                    debug!(gas_used = ?gas_used, "transaction executed successfully");
                 }
                 Err(err) => {
                     tracing::warn!(error = %err, tx_hash = %tx.tx_hash(), "transaction execution failed");

--- a/crates/node/src/executor.rs
+++ b/crates/node/src/executor.rs
@@ -411,7 +411,7 @@ where
         .map(|(sink, activation)| {
             info!(
                 target = "ev-reth::executor",
-                fee_sink = ?sink,
+                fee_sink = %sink,
                 activation_height = activation,
                 "Base fee redirect enabled"
             );

--- a/crates/node/src/payload_service.rs
+++ b/crates/node/src/payload_service.rs
@@ -45,7 +45,7 @@ impl EvolvePayloadBuilderBuilder {
     /// Create a new builder with evolve args.
     pub fn new() -> Self {
         let config = EvolvePayloadBuilderConfig::new();
-        info!("Created Evolve payload builder with config: {:?}", config);
+        info!("created evolve payload builder");
         Self { config }
     }
 }
@@ -138,7 +138,7 @@ where
         if let Some(sink) = self.config.base_fee_sink_for_block(block_number) {
             info!(
                 target: "ev-reth",
-                fee_sink = ?sink,
+                fee_sink = %sink,
                 block_number,
                 "Suggested fee recipient missing; defaulting to base-fee sink"
             );

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -80,7 +80,7 @@ impl PayloadValidator<EvolveEngineTypes> for EvolveEngineValidator {
                     .map_err(|e| NewPayloadError::Other(e.into()))
             }
             Err(err) => {
-                debug!(error = ?err, "payload validation error");
+                debug!(error = %err, "payload validation error");
 
                 // Check if this is an error we can bypass for evolve:
                 // 1. BlockHash mismatch - ev-reth computes different hash due to custom tx types
@@ -96,7 +96,7 @@ impl PayloadValidator<EvolveEngineTypes> for EvolveEngineValidator {
                         || is_unknown_tx_type_error(&err);
 
                 if should_bypass {
-                    info!(error = ?err, "bypassing validation error for ev-reth");
+                    info!(error = %err, "bypassing validation error for ev-reth");
                     // For evolve, we trust the payload builder - parse the block with EvNode support.
                     let ev_block = parse_evolve_payload(payload)?;
                     Span::current().record("block_hash", tracing::field::display(ev_block.hash()));


### PR DESCRIPTION


## Description

<!-- Please include a summary of the changes and the related issue. -->

## Type of Change

Some telemetry outputs were using Debug formatting, so were repesented as `Some(1000)` rather than `"1000"`. This PR updates the outputs to be non-rust specific for easier parsing.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues

<!-- Link to any related issues -->
Fixes #(issue)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and improved internal logging and tracing output for better readability and consistency across mint, node, payload builder, executor, and validator components. No functional behavior, public interfaces, or state changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->