### PR TITLE
docs: prepare changelog for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-17
+
 ### Added
 
 - Optional proposer-control precompile at `0xF101` for execution-owned ev-node proposer rotation. Enable with `proposerControlAdmin` in `config.evolve`; optional `proposerControlActivationHeight` (defaults to `0`) and `initialNextProposer` (32-byte word). Exposes `evolve_getNextProposer` only when the admin is configured ([#228](https://github.com/evstack/ev-reth/pull/228))
+
+### Changed
+
+- Upgraded Reth from v2.2.0 to v2.5.0, with matching Alloy 2.3, revm 42.0.1, alloy-evm 0.38.0, reth-codecs / reth-primitives-traits 0.6, and related dependency updates. Custom EVM batching, RPC, codec, and txpool integrations were migrated to the v2.5 APIs, including batch runtime-gas accounting ([#266](https://github.com/evstack/ev-reth/pull/266), [#338](https://github.com/evstack/ev-reth/pull/338), [#363](https://github.com/evstack/ev-reth/pull/363))
+
+### Removed
+
+- `ev-deployer` CLI and `ev-dev` local-development TUI. Genesis allocs and local nets should use the Foundry scripts under `contracts/` and a standard ev-reth / ev-node stack ([#349](https://github.com/evstack/ev-reth/pull/349))
+
+## [0.4.1] - 2026-06-16
+
+### Added
+
 - Lightweight custom chainspec mode (`--chain light:<path-or-json>`) for warm datadir restarts without reparsing large genesis allocs, including automatic `.light.json` sidecar generation from full file-based genesis specs ([#253](https://github.com/evstack/ev-reth/pull/253))
 
 ### Changed

--- a/docs/UPGRADE-v0.5.0.md
+++ b/docs/UPGRADE-v0.5.0.md
@@ -4,7 +4,16 @@ This guide covers the configuration changes required to upgrade ev-reth to v0.5.
 
 ## Upgrading from v0.4.x
 
-No configuration changes are required. Rebuild and deploy the new binary. Existing chains keep current proposer behavior until `proposerControlAdmin` is set.
+No chainspec changes are required for existing networks. Rebuild and deploy the new binary. Existing chains keep current proposer behavior until `proposerControlAdmin` is set.
+
+Reth is now v2.5.0 (from v2.2.0 in v0.4.1). That is an internal engine bump: no new required `config` fields.
+
+### Removed tooling
+
+`ev-deployer` and `ev-dev` were removed. If you used them:
+
+- Generate genesis allocs with the Foundry scripts under `contracts/script/` (`GenerateFeeVaultAlloc`, `GenerateAdminProxyAlloc`)
+- Run a local stack with the `ev-reth` binary plus ev-node, not `ev-dev`
 
 ## New Features
 


### PR DESCRIPTION
## Summary

- Promote Unreleased notes into `## [0.5.0]` (proposer precompile, Reth 2.5, ev-deployer/ev-dev removal)
- Backfill `## [0.4.1]` — those notes were merged under Unreleased in #279 and the `v0.4.1` tag is off-main
- Document the removed binaries in `docs/UPGRADE-v0.5.0.md`

## After merge

```bash
git checkout main && git pull
git tag -a v0.5.0 -m "v0.5.0"
git push origin v0.5.0
```

Pushing the tag triggers `.github/workflows/release.yml` (binaries + GitHub release). There are currently git tags but no GitHub releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.5.0, including the proposer-control precompile and major tooling changes.
  * Added upgrade guidance confirming no chainspec changes or new required configuration fields for existing networks.
  * Documented the removal of `ev-deployer` and `ev-dev`, along with replacement workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->